### PR TITLE
Use local Earth Engine credentials in Docker environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
 		"dockerfile": "./Dockerfile"
 	},
 	"mounts": [
-		"source=${localWorkspaceFolder},target=/app,type=bind,consistency=cached"
+		"source=${localWorkspaceFolder},target=/app,type=bind,consistency=cached",
+		"source=${env:HOME}${env:USERPROFILE}/.config,target=/root/.config,type=bind,consistency=cached"
 	],
 	"containerEnv": {
 		// Silence TF info and warning messages


### PR DESCRIPTION
This resolves #9 by mounting the local `~/.config` folder that contains Earth Engine credentials to the Docker container. This allows for initializing Earth Engine with stored local credentials instead of having to authenticate every time the container is rebuilt.

There are some possible side effects to this as it removes the isolation between the local and Docker Earth Engine environments, including:
- Whatever account is authenticated locally will be used in the Docker environment, which might not be intended
- Re-authenticating in the Docker container will modify the local credentials

I think those trade-offs are worth the convenience, but we can always revisit this if it turns out to be problematic.