### PR TITLE
Pin base image to `tensorflow/tensorflow:2.13.0-gpu-jupyter`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:latest-gpu-jupyter
+FROM tensorflow/tensorflow:2.13.0-gpu-jupyter
 
 RUN python -m pip install --upgrade pip setuptools wheel
 


### PR DESCRIPTION
Closes #15 

The `latest` build that was previously used broke the training notebook when it was upgraded to `2.14.0`, so this pins to the latest stable version.