### PR TITLE
Fix data leakage caused by reshuffling before splitting

### DIFF
--- a/src/naip_cnn/data.py
+++ b/src/naip_cnn/data.py
@@ -149,7 +149,9 @@ class _HDF5DatasetMixin:
         ds = tf.data.Dataset.zip((features, labels))
 
         if shuffle:
-            ds = ds.shuffle(self.n_samples, seed=seed)
+            # Using `reshuffle_each_iteration` before splitting leaks data. See
+            # https://github.com/tensorflow/tensorflow/issues/59279
+            ds = ds.shuffle(self.n_samples, seed=seed, reshuffle_each_iteration=False)
 
         if feature_preprocessor is not None or label_preprocessor is not None:
             feature_preprocessor = feature_preprocessor or (lambda x: x)


### PR DESCRIPTION
I thought those MSEs were too good to be true... @grovduck There's not much to review here, but just wanted to make you aware of the change and make sure this didn't raise any other red flags elsewhere in the code. I need to re-run things to get an idea of exactly how much the scores will drop and what that means for the different scale comparisons, but I don't think it's going to be pretty!

The Problem
-----------

To avoid artificial differences between our train/test/validation sets, we shuffle the entire dataset prior to splitting. When run, this creates a data loading pipeline that looks roughly like:

```
load data -> shuffle -> split
```

By default, the shuffle method will reshuffle on each iteration through the dataset, i.e. every epoch. This means that we get a different split every epoch, allowing samples to leak between sets, inflating model performance.

This issue is outlined here:

https://github.com/tensorflow/tensorflow/issues/59279

And pointed out in the comments to this SO answer that would introduce this leakage:

https://stackoverflow.com/a/51258695/17707273

The Solution
------------

Use `reshuffle_each_iteration=False` to prevent reshuffling on each iteration. The dataset will now be loaded, shuffled, and split only once.