### PR TITLE
Add `--split` option to allow validating with test set

### DIFF
--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -34,6 +34,7 @@ validation_acquisitions = [
 if __name__ == "__main__":
     for run in runs:
         for acquisition in validation_acquisitions:
-            print(f"Validating {run} with {acquisition}")
-            metrics = validate(run, acquisition, dry_run=False, split="validation")
-            print(metrics)
+            for split in ("validation", "test"):
+                print(f"Validating {run} {split} set with {acquisition}")
+                metrics = validate(run, acquisition, dry_run=False, split=split)
+                print(metrics)

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -35,5 +35,5 @@ if __name__ == "__main__":
     for run in runs:
         for acquisition in validation_acquisitions:
             print(f"Validating {run} with {acquisition}")
-            metrics = validate(run, acquisition, dry_run=False)
+            metrics = validate(run, acquisition, dry_run=False, split="validation")
             print(metrics)

--- a/src/naip_cnn/cli/__main__.py
+++ b/src/naip_cnn/cli/__main__.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import click
 
 from naip_cnn.utils.wandb import compare_runs
@@ -74,10 +76,17 @@ def check_cmd(dataset: str) -> None:
 @cli.command(name="validate")
 @click.argument("run_path")
 @click.argument("acquisition_name")
+@click.option(
+    "--split", type=click.Choice(["validation", "test"]), default="validation"
+)
 @click.option("--batch-size", type=int, default=256)
 @click.option("--dry-run", is_flag=True)
 def validation_command(
-    run_path: str, acquisition_name: str, batch_size: int = 256, dry_run: bool = False
+    run_path: str,
+    acquisition_name: str,
+    split: Literal["validation", "test"],
+    batch_size: int = 256,
+    dry_run: bool = False,
 ):
     """
     Validate a model using a given validation dataset.
@@ -85,6 +94,7 @@ def validation_command(
     validate(
         run_path,
         acquisition_name=acquisition_name,
+        split=split,
         batch_size=batch_size,
         dry_run=dry_run,
     )


### PR DESCRIPTION
As discussed in #23, this provides a way to generate metrics using the test split in addition to the validation split with the new `--split=test` argument in the CLI or `split="test"` argument in the API. I updated the `run_validation` script to execute both options and ran this, so you can see results in W&B for the listed runs under the new "test" key in the run summary metrics.

For example: https://wandb.ai/aazuspan-team/naip-cnn/runs/dmrpcb14/overview

