### PR TITLE
Use consistent NAIP orientation during prediction

### DIFF
--- a/src/naip_cnn/data.py
+++ b/src/naip_cnn/data.py
@@ -525,10 +525,10 @@ class NAIPTFRecord:
         # to the GDAL convention of [c a b f d e] or shapely [a b d e c f] where:
         # a = pixel width
         # b = row rotation (typically zero)
-        # c = x-coordinate of upper-left pixel
+        # c = x-coordinate of the origin pixel
         # d = column rotation (typically zero)
         # e = pixel height (typically negative)
-        # f = y-coordinate of upper-left pixel
+        # f = y-coordinate of the origin pixel
         # Also see https://gdal.org/en/stable/tutorials/geotransforms_tut.html
         if self.profile["transform"][4] < 0:
             image = tf.image.flip_up_down(image)


### PR DESCRIPTION
Closes #25 

Explicitly setting the export CRS in 2b8d162 (squashed into 11c3490) altered the affine transform so that NAIP is stored north-up (negative pixel height), compared to the south-up used during training. This adds a check while loading TFRecords to flip imagery based on the affine transform to match the positive x and y resolution used during training.

I included an east-west flip in case of a negative x-resolution for safety, although that hasn't happened in practice.

Note that it would probably be slightly more performant to instead export data south-up and skip the on-the-fly correction, but 1) setting the explicit CRS at least ensures *consistent* results, and 2) we already have a substantial amount of data exported north-up.