### PR TITLE
Set a fixed geotransform and dimensions for NAIP exports

### DIFF
--- a/notebooks/02_export_naip.ipynb
+++ b/notebooks/02_export_naip.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import ee\n",
     "\n",
-    "from naip_cnn.config import DIMENSIONS, ORIGIN\n",
+    "from naip_cnn.config import NAIP_DIMENSIONS, NAIP_RES, ORIGIN\n",
     "from naip_cnn.data import NAIPTFRecord\n",
     "\n",
     "ee.Initialize()"
@@ -43,7 +43,7 @@
     "naip = NAIPTFRecord(\n",
     "    id=\"STUDY_REGION\",\n",
     "    footprint=(30, 30),\n",
-    "    res=1.0,\n",
+    "    res=NAIP_RES,\n",
     "    year=2018,\n",
     "    # Add a buffer to ensure that NAIP covers the entire export region\n",
     "    bounds=STUDY_REGION.bounds().buffer(5_000),\n",
@@ -53,7 +53,7 @@
     "    clip=None,\n",
     "    export_mask=False,\n",
     "    origin=ORIGIN,\n",
-    "    dimensions=DIMENSIONS,\n",
+    "    dimensions=NAIP_DIMENSIONS,\n",
     ")"
    ]
   },

--- a/notebooks/02_export_naip.ipynb
+++ b/notebooks/02_export_naip.ipynb
@@ -11,21 +11,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.19) or chardet (3.0.4) doesn't match a supported version!\n",
-      "  warnings.warn(\"urllib3 ({}) or chardet ({}) doesn't match a supported \"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import ee\n",
     "\n",
+    "from naip_cnn.config import DIMENSIONS, ORIGIN\n",
     "from naip_cnn.data import NAIPTFRecord\n",
     "\n",
     "ee.Initialize()"
@@ -33,57 +25,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "BLUE_MTNS = (\n",
-    "    ee.FeatureCollection(\"projects/ee-aazuspan/assets/ecoregions\")\n",
-    "    .filter(ee.Filter.eq(\"NA_L3NAME\", \"Blue Mountains\"))\n",
-    "    .first()\n",
-    ").geometry()\n",
-    "\n",
-    "\n",
-    "MALHEUR = (\n",
-    "    ee.FeatureCollection(\"USGS/GAP/PAD-US/v20/fee\")\n",
-    "    .filter(ee.Filter.eq(\"Loc_Nm\", \"Malheur National Forest\"))\n",
-    "    .first()\n",
-    ").geometry()\n",
-    "\n",
-    "\n",
-    "STUDY_AREA = ee.FeatureCollection(\n",
+    "STUDY_REGION = ee.FeatureCollection(\n",
     "    \"projects/ee-maptheforests/assets/USFS_RD_CNN\"\n",
-    ").geometry()\n",
-    "\n",
-    "\n",
-    "TEST_BBOX = ee.Geometry.Polygon(\n",
-    "    [\n",
-    "        [\n",
-    "            [-119.37239004502233, 44.48079613290612],\n",
-    "            [-118.57725454697545, 44.48079613290612],\n",
-    "            [-118.57725454697545, 44.81785572318615],\n",
-    "            [-119.37239004502233, 44.81785572318615],\n",
-    "        ]\n",
-    "    ]\n",
-    ")\n",
-    "\n",
-    "# A BBOX around the 2015 Canyon Creek fire, which includes a weird section of blurry\n",
-    "# NAIP in 2011 that causes issues for the model.\n",
-    "CANYON_CREEK = ee.Geometry.Polygon(\n",
-    "    [\n",
-    "        [\n",
-    "            [-119.04311610904354, 44.393977631186324],\n",
-    "            [-119.04311610904354, 44.16095221729865],\n",
-    "            [-118.61464931216854, 44.16095221729865],\n",
-    "            [-118.61464931216854, 44.393977631186324],\n",
-    "        ]\n",
-    "    ]\n",
-    ")"
+    ").geometry()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,37 +44,24 @@
     "    id=\"STUDY_REGION\",\n",
     "    footprint=(30, 30),\n",
     "    res=1.0,\n",
-    "    year=2012,\n",
-    "    bounds=STUDY_AREA.bounds(),\n",
+    "    year=2018,\n",
+    "    # Add a buffer to ensure that NAIP covers the entire export region\n",
+    "    bounds=STUDY_REGION.bounds().buffer(5_000),\n",
     ")\n",
     "\n",
-    "task = naip.export_to_drive(clip=None, export_mask=False)"
+    "task = naip.export_to_drive(\n",
+    "    clip=None,\n",
+    "    export_mask=False,\n",
+    "    origin=ORIGIN,\n",
+    "    dimensions=DIMENSIONS,\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'state': 'READY',\n",
-       " 'description': 'STUDY_REGION-2012-1-30x30',\n",
-       " 'priority': 100,\n",
-       " 'creation_timestamp_ms': 1749692178041,\n",
-       " 'update_timestamp_ms': 1749692178041,\n",
-       " 'start_timestamp_ms': 0,\n",
-       " 'task_type': 'EXPORT_IMAGE',\n",
-       " 'id': '6WQGQWWFNKUBECCX3CG24UFM',\n",
-       " 'name': 'projects/ee-aazuspan/operations/6WQGQWWFNKUBECCX3CG24UFM'}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "task.status()"
    ]
@@ -143,7 +83,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "tqdm",
     "spyndex",
     "click",
+    "pytest>=9.0.2",
 ]
 
 [tool.hatch.version]

--- a/src/naip_cnn/config.py
+++ b/src/naip_cnn/config.py
@@ -40,7 +40,7 @@ CRS = (
 # export parameters.
 BASE_TRANSFORM = (1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
 # Snap size in meters for aligning exports to a fixed grid
-GRID_SNAP = 30
+GRID_SNAP = 30.0
 # Pre-computed origin point at the top-left of the study area
 ORIGIN = (603870, 1273200)
 # Pre-computed dimensions in meters to cover the study area

--- a/src/naip_cnn/config.py
+++ b/src/naip_cnn/config.py
@@ -1,3 +1,4 @@
+import math
 from pathlib import Path
 
 # The Earth Engine path where assets are stored
@@ -39,20 +40,26 @@ CRS = (
 # Base geotransform for GEE exports. The origin and pixel size are adjusted based on the
 # export parameters.
 BASE_TRANSFORM = (1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
-# Snap size in meters for aligning exports to a fixed grid
+# Snap size in projection units (i.e. meters) for aligning exports to a fixed grid
 GRID_SNAP = 30.0
-# Pre-computed origin point at the top-left of the study area
+# Pre-computed origin point in projection units (i.e. meters) at the top-left of the
+# study area.
 ORIGIN = (603870, 1273200)
-# Pre-computed dimensions in meters to cover the study area
+# Pre-computed dimensions in projection units (i.e. meters) to cover the study area
 DIMENSIONS = (182_100, 214_110)
 
 # The NAIP bands stored during sampling. Subsets of these bands may be used during
 # training, but all bands will be present in the datasets.
 BANDS = ("R", "G", "B", "N")
 
-# Spatial resolution in meters to extract and predict at
+# Spatial resolution in projection units (i.e. meters) to extract and predict at
 NAIP_RES = 1.0
 LIDAR_RES = 30.0
+
+# Dimensions in pixels for NAIP and LiDAR data, computed from the base dimensions and
+# resolutions
+NAIP_DIMENSIONS = tuple(math.ceil(d * NAIP_RES) for d in DIMENSIONS)
+LIDAR_DIMENSIONS = tuple(math.ceil(d * LIDAR_RES) for d in DIMENSIONS)
 
 # The name of the Weights and Biases project where results are logged
 WANDB_PROJECT = "naip-cnn"

--- a/src/naip_cnn/config.py
+++ b/src/naip_cnn/config.py
@@ -36,6 +36,11 @@ CRS = (
     'AXIS["Y",NORTH]]'
 )
 
+# Base geotransform for GEE exports. The origin and pixel size may need to be adjusted
+# depending on the dataset and region.
+BASE_TRANSFORM = (1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
+GRID_SNAP = 30  # Snap grid size in meters for aligning exports
+
 # The NAIP bands stored during sampling. Subsets of these bands may be used during
 # training, but all bands will be present in the datasets.
 BANDS = ("R", "G", "B", "N")

--- a/src/naip_cnn/config.py
+++ b/src/naip_cnn/config.py
@@ -36,10 +36,15 @@ CRS = (
     'AXIS["Y",NORTH]]'
 )
 
-# Base geotransform for GEE exports. The origin and pixel size may need to be adjusted
-# depending on the dataset and region.
+# Base geotransform for GEE exports. The origin and pixel size are adjusted based on the
+# export parameters.
 BASE_TRANSFORM = (1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
-GRID_SNAP = 30  # Snap grid size in meters for aligning exports
+# Snap size in meters for aligning exports to a fixed grid
+GRID_SNAP = 30
+# Pre-computed origin point at the top-left of the study area
+ORIGIN = (603870, 1273200)
+# Pre-computed dimensions in meters to cover the study area
+DIMENSIONS = (182_100, 214_110)
 
 # The NAIP bands stored during sampling. Subsets of these bands may be used during
 # training, but all bands will be present in the datasets.

--- a/src/naip_cnn/data.py
+++ b/src/naip_cnn/data.py
@@ -20,6 +20,7 @@ from naip_cnn.config import (
     BASE_TRANSFORM,
     CRS,
     GRID_SNAP,
+    LIDAR_RES,
     NAIP_RES,
     TFRECORD_DIR,
     TRAIN_DIR,
@@ -456,7 +457,7 @@ class NAIPTFRecord:
                 mask_dimensions = compute_dimensions(
                     region=self.bounds,
                     origin=origin,
-                    scale=30.0,  # Mask is always at 30m resolution
+                    scale=LIDAR_RES,
                     snap_size=GRID_SNAP,
                     proj=ee.Projection(CRS),
                 )
@@ -471,7 +472,7 @@ class NAIPTFRecord:
                 crsTransform=compose_transform(
                     BASE_TRANSFORM,
                     origin=origin,
-                    scale=30.0,
+                    scale=LIDAR_RES,
                 ),
                 # The CRS transform origin will be ignored if `region` is provided, so
                 # we need to calculate dimensions manually.

--- a/src/naip_cnn/utils/parsing.py
+++ b/src/naip_cnn/utils/parsing.py
@@ -19,3 +19,12 @@ def str_to_float(s: str) -> float:
     - '1' -> 1.0
     """
     return float(s.replace("p", "."))
+
+
+def dimensions_to_str(dimensions: tuple[int, int]) -> str:
+    """Stringify dimensions for GEE.
+
+    For example:
+    - (256, 256) -> '256x256'
+    """
+    return f"{dimensions[0]}x{dimensions[1]}"

--- a/src/naip_cnn/utils/transform.py
+++ b/src/naip_cnn/utils/transform.py
@@ -11,8 +11,8 @@ def compute_snapped_origin(
     max_error: float = 1.0,
 ) -> tuple[float, float]:
     """
-    Compute an origin point (top-left corner) in projection units that encompasses the
-    given region and is snapped to the specified grid size.
+    Compute an origin point (top-left corner) in projection units for the given region,
+    snapped to the specified size.
     """
     bbox = region.bounds(max_error, proj=proj)
     coords = np.asarray(bbox.coordinates().get(0).getInfo())

--- a/src/naip_cnn/utils/transform.py
+++ b/src/naip_cnn/utils/transform.py
@@ -1,0 +1,41 @@
+import math
+
+import ee
+import numpy as np
+
+
+def compute_snapped_origin(
+    region: ee.Geometry,
+    snap_size: int,
+    proj: ee.Projection,
+    max_error: float = 1.0,
+) -> tuple[float, float]:
+    """
+    Compute an origin point (top-left corner) that encompasses the given region
+    and is snapped to the specified pixel size.
+    """
+    bbox = region.bounds(max_error, proj=proj)
+    coords = np.asarray(bbox.coordinates().get(0).getInfo())
+    minx = coords[:, 0].min()
+    maxy = coords[:, 1].max()
+    origin_x = np.floor(minx / snap_size) * snap_size
+    origin_y = np.ceil(maxy / snap_size) * snap_size
+    return origin_x, origin_y
+
+
+def compose_transform(
+    base_transform: list[float],
+    origin: tuple[float, float],
+    scale: float,
+) -> list[float]:
+    """
+    Compose an affine transform given a base transform, origin, and scale.
+    """
+    return [
+        math.copysign(scale, base_transform[0]),
+        base_transform[1],
+        origin[0],
+        base_transform[3],
+        math.copysign(scale, base_transform[4]),
+        origin[1],
+    ]

--- a/src/naip_cnn/utils/transform.py
+++ b/src/naip_cnn/utils/transform.py
@@ -11,8 +11,8 @@ def compute_snapped_origin(
     max_error: float = 1.0,
 ) -> tuple[float, float]:
     """
-    Compute an origin point (top-left corner) that encompasses the given region
-    and is snapped to the specified pixel size.
+    Compute an origin point (top-left corner) in projection units that encompasses the
+    given region and is snapped to the specified grid size.
     """
     bbox = region.bounds(max_error, proj=proj)
     coords = np.asarray(bbox.coordinates().get(0).getInfo())
@@ -40,12 +40,16 @@ def compute_dimensions(
     maxx = coords[:, 0].max()
     miny = coords[:, 1].min()
 
-    width = int(math.ceil((maxx - origin[0]) / scale))
-    height = int(math.ceil((origin[1] - miny) / scale))
+    projected_width = maxx - origin[0]
+    projected_height = origin[1] - miny
 
-    # Snap dimensions up to the nearest multiple of snap_size
-    width = int(math.ceil(width / snap_size) * snap_size)
-    height = int(math.ceil(height / snap_size) * snap_size)
+    # Snap projected dimensions up to the nearest multiple of snap_size
+    projected_width = math.ceil(projected_width / snap_size) * snap_size
+    projected_height = math.ceil(projected_height / snap_size) * snap_size
+
+    # Convert snapped projected dimensions to pixels
+    width = int(round(projected_width / scale))
+    height = int(round(projected_height / scale))
 
     return width, height
 

--- a/src/naip_cnn/utils/transform.py
+++ b/src/naip_cnn/utils/transform.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def compute_snapped_origin(
     region: ee.Geometry,
-    snap_size: int,
+    snap_size: float,
     proj: ee.Projection,
     max_error: float = 1.0,
 ) -> tuple[float, float]:
@@ -27,7 +27,7 @@ def compute_dimensions(
     region: ee.Geometry,
     origin: tuple[float, float],
     scale: float,
-    snap_size: int,
+    snap_size: float,
     proj: ee.Projection,
     max_error: float = 1.0,
 ) -> tuple[int, int]:

--- a/src/naip_cnn/utils/transform.py
+++ b/src/naip_cnn/utils/transform.py
@@ -23,6 +23,33 @@ def compute_snapped_origin(
     return origin_x, origin_y
 
 
+def compute_dimensions(
+    region: ee.Geometry,
+    origin: tuple[float, float],
+    scale: float,
+    snap_size: int,
+    proj: ee.Projection,
+    max_error: float = 1.0,
+) -> tuple[int, int]:
+    """
+    Compute the dimensions (width, height) in pixels required to cover the given
+    region from the specified origin at the given scale.
+    """
+    bbox = region.bounds(max_error, proj=proj)
+    coords = np.asarray(bbox.coordinates().get(0).getInfo())
+    maxx = coords[:, 0].max()
+    miny = coords[:, 1].min()
+
+    width = int(math.ceil((maxx - origin[0]) / scale))
+    height = int(math.ceil((origin[1] - miny) / scale))
+
+    # Snap dimensions up to the nearest multiple of snap_size
+    width = int(math.ceil(width / snap_size) * snap_size)
+    height = int(math.ceil(height / snap_size) * snap_size)
+
+    return width, height
+
+
 def compose_transform(
     base_transform: list[float],
     origin: tuple[float, float],

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,4 @@
+def pytest_sessionstart(session):
+    import ee
+
+    ee.Initialize()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,7 +13,7 @@ def test_compute_snapped_origin():
     geometry = ee.Geometry.Rectangle([-119.497, 44.749, -118.299, 43.924])
     assert compute_snapped_origin(
         geometry,
-        snap_size=30,
+        snap_size=30.0,
         proj=ee.Projection(CRS),
     ) == (639780, 1188420)
 
@@ -37,7 +37,7 @@ def test_compute_dimensions():
             geometry,
             origin,
             scale,
-            snap_size=30,
+            snap_size=30.0,
             proj=ee.Projection(CRS),
         )
         == expected_dimensions

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import ee
+import pytest
 
 from naip_cnn.config import CRS
 from naip_cnn.utils.transform import (
@@ -26,12 +27,12 @@ def test_compose_transform():
     assert compose_transform(base_transform, origin, scale) == expected_transform
 
 
-def test_compute_dimensions():
+@pytest.mark.parametrize("scale", [1.0, 30.0])
+def test_compute_dimensions(scale: float):
     # Use an arbitrary rectangle as a pseudo regression test
     geometry = ee.Geometry.Rectangle([-119.497, 44.749, -118.299, 43.924])
     origin = (603930, 1272330)
-    scale = 1.0
-    expected_dimensions = (132600, 176970)
+    expected_dimensions = (132600 // scale, 176970 // scale)
     assert (
         compute_dimensions(
             geometry,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,14 +9,13 @@ from naip_cnn.utils.transform import (
 
 
 def test_compute_snapped_origin():
-    geometry = ee.FeatureCollection(
-        "projects/ee-maptheforests/assets/USFS_RD_CNN"
-    ).geometry()
+    # Use an arbitrary rectangle as a pseudo regression test
+    geometry = ee.Geometry.Rectangle([-119.497, 44.749, -118.299, 43.924])
     assert compute_snapped_origin(
         geometry,
         snap_size=30,
         proj=ee.Projection(CRS),
-    ) == (603930, 1272330)
+    ) == (639780, 1188420)
 
 
 def test_compose_transform():
@@ -28,12 +27,11 @@ def test_compose_transform():
 
 
 def test_compute_dimensions():
-    geometry = ee.FeatureCollection(
-        "projects/ee-maptheforests/assets/USFS_RD_CNN"
-    ).geometry()
+    # Use an arbitrary rectangle as a pseudo regression test
+    geometry = ee.Geometry.Rectangle([-119.497, 44.749, -118.299, 43.924])
     origin = (603930, 1272330)
     scale = 1.0
-    expected_dimensions = (181890, 213030)
+    expected_dimensions = (132600, 176970)
     assert (
         compute_dimensions(
             geometry,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,23 @@
+import ee
+
+from naip_cnn.config import CRS
+from naip_cnn.utils.transform import compose_transform, compute_snapped_origin
+
+
+def test_compute_snapped_origin():
+    geometry = ee.FeatureCollection(
+        "projects/ee-maptheforests/assets/USFS_RD_CNN"
+    ).geometry()
+    assert compute_snapped_origin(
+        geometry,
+        snap_size=30,
+        proj=ee.Projection(CRS),
+    ) == (603930, 1272330)
+
+
+def test_compose_transform():
+    base_transform = [30, 0, 0, 0, -30, 0]
+    origin = (603930, 1272330)
+    scale = 1.0
+    expected_transform = [1.0, 0, 603930, 0, -1.0, 1272330]
+    assert compose_transform(base_transform, origin, scale) == expected_transform

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,11 @@
 import ee
 
 from naip_cnn.config import CRS
-from naip_cnn.utils.transform import compose_transform, compute_snapped_origin
+from naip_cnn.utils.transform import (
+    compose_transform,
+    compute_dimensions,
+    compute_snapped_origin,
+)
 
 
 def test_compute_snapped_origin():
@@ -21,3 +25,22 @@ def test_compose_transform():
     scale = 1.0
     expected_transform = [1.0, 0, 603930, 0, -1.0, 1272330]
     assert compose_transform(base_transform, origin, scale) == expected_transform
+
+
+def test_compute_dimensions():
+    geometry = ee.FeatureCollection(
+        "projects/ee-maptheforests/assets/USFS_RD_CNN"
+    ).geometry()
+    origin = (603930, 1272330)
+    scale = 1.0
+    expected_dimensions = (181890, 213030)
+    assert (
+        compute_dimensions(
+            geometry,
+            origin,
+            scale,
+            snap_size=30,
+            proj=ee.Projection(CRS),
+        )
+        == expected_dimensions
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -939,6 +939,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ipykernel"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,6 +1470,7 @@ dependencies = [
     { name = "pandas" },
     { name = "plotly" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "rasterio" },
     { name = "scikit-learn" },
     { name = "spyndex" },
@@ -1484,6 +1494,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "plotly" },
     { name = "pre-commit" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "rasterio" },
     { name = "scikit-learn" },
     { name = "spyndex" },
@@ -1988,6 +1999,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2293,6 +2313,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This would close #17 by using a fixed, calculated geotransform and dimensions when exporting NAIP imagery for prediction. The origin point and image dimensions are calculated manually from the selected region, scale, and a snap size to (hopefully) ensure that predicted outputs are aligned with other data products like GNN. This was necessary because we want to align to a 30m grid with a 1m resolution, which isn't something that GEE can handle automatically.

@grovduck, I'm opening this as a draft for now because I haven't managed to get a successful export for the entire study area yet. For some reason, specifying `dimensions` seemed to dramatically slow down TFRecord exports based on some experiments I ran in a small test area (from 15 min to 3 hrs). I have an export running for the entire study area that's on attempt 2 after running for around 6 hours (186 EECU hours and counting), and I don't have high hopes that it will ever complete.

Let me know if you've ever run into anything like this before or see any silly mistakes that I made. If not and this is just a weird bug with TFRecords and `dimensions`, maybe we need to consider another approach.

EDIT: The full study area export did complete on the 2nd attempt after 12 hours (255 EECU hours), so this may be a workable solution after all.

FYI the only change to `pyproject.toml` was adding `pytest` to the dependencies (finally some tests!) - I'm not sure why the diff includes everything...